### PR TITLE
feat: improve timer management with enhanced pause/resume handling

### DIFF
--- a/src/app/sudoku/components/congratulations-dialog/congratulations-dialog.component.html
+++ b/src/app/sudoku/components/congratulations-dialog/congratulations-dialog.component.html
@@ -33,7 +33,7 @@
         class="btn btn-reset" 
         (click)="onResetGame()">
         <i class="fas fa-redo"></i>
-        Reset Game
+        Restart Game
       </button>
       
       <button 

--- a/src/app/sudoku/components/controls/controls.component.html
+++ b/src/app/sudoku/components/controls/controls.component.html
@@ -8,7 +8,7 @@
   </button>
   <button class="reset-btn" (click)="onResetClick()" [disabled]="disabled || resetDisabled">
     <i class="fas fa-redo"></i>
-    Reset Game
+    Restart Game
   </button>
 </div>
 

--- a/src/app/sudoku/components/timer/timer.component.ts
+++ b/src/app/sudoku/components/timer/timer.component.ts
@@ -118,6 +118,15 @@ export class TimerComponent implements OnInit, OnDestroy, OnChanges {
     }
   }
 
+  // Public method to resume timer when game is unpaused
+  resumeGameTimer() {
+    if (this.isPaused) {
+      this.continueTimer();
+    } else if (this.hasStarted && !this.timerInterval) {
+      this.startTimer();
+    }
+  }
+
   stopTimer() {
     if (this.timerInterval) {
       clearInterval(this.timerInterval);
@@ -273,11 +282,16 @@ export class TimerComponent implements OnInit, OnDestroy, OnChanges {
       }
     }
     
-    if (changes['isGameActive'] || changes['isGameCompleted']) {
-      if (!this.isGameActive || this.isGameCompleted) {
+    if (changes['isGameActive'] || changes['isGameCompleted'] || changes['isGamePaused']) {
+      if (!this.isGameActive || this.isGameCompleted || this.isGamePaused) {
         this.pauseTimer();
-      } else if (this.isGameActive && !this.isGameCompleted && this.hasStarted && !this.isPaused) {
-        this.startTimer();
+      } else if (this.isGameActive && !this.isGameCompleted && !this.isGamePaused && this.hasStarted) {
+        // Resume timer when game becomes active and not paused
+        if (this.isPaused) {
+          this.continueTimer();
+        } else if (!this.timerInterval) {
+          this.startTimer();
+        }
       }
     }
   }


### PR DESCRIPTION
- Added `resumeGameTimer` method in `TimerComponent` to support seamless game timer resumption.
- Updated game pause/resume logic in `SudokuComponent`, ensuring timer behavior aligns with game state transitions.
- Integrated timer pausing on navigation, component destruction, and page unload for proper state preservation.
- Refined keyboard handling to allow pausing the game with the Escape key.
- Adjusted UI terminology from "Reset Game" to "Restart Game" for clarity and consistency.